### PR TITLE
Fix tab indentation in labeler.yml causing triage job to fail

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 bug 🐛:
     - '- :bug: Bug'
 feature ➕:
-	- '- :heavy_plus_sign: Feature request'
+    - '- :heavy_plus_sign: Feature request'
 performance 🐌:
-	- '- :snail: Performance issue'
+    - '- :snail: Performance issue'
 question ❓:
-	- '- :question: Question'
+    - '- :question: Question'


### PR DESCRIPTION
## Summary

- The `triage` workflow job (which runs `github/issue-labeler`) was failing with `YAMLException: tab characters must not be used in indentation` on every issue.
- `.github/labeler.yml` mixed space indentation (line 2) with tab indentation (lines 4, 6, 8), which is invalid YAML.
- Replaced the tab characters with spaces so the file parses correctly, matching the existing style.

Fixes the failure seen at https://github.com/comunica/comunica-feature-solid/actions/runs/29132294115/job/86489790281

## Test plan

- [x] Validated the updated `.github/labeler.yml` parses successfully with a YAML parser (`yaml.safe_load`)
- [ ] Confirm the `triage` job succeeds on the next issue/PR triggering the workflow


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBcSWvehGm7KczhkJxf2Pu)_